### PR TITLE
Change rgl.* calls to *3d

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -50,7 +50,7 @@
              "resid", "rnorm", "runif", "scatter.smooth", "sd",
              "splinefun", "terms", "var")
   importFrom("utils", "capture.output", "file_test", "flush.console",
-             "str", "tail", "write.table")
+             "str", "head", "tail", "write.table")
 
 
 S3method(plot, dice)

--- a/R/flip.rgl.coin.R
+++ b/R/flip.rgl.coin.R
@@ -1,7 +1,7 @@
 flip.rgl.coin <- function(side=sample(2,1), steps=150) {
 
   for (i in seq(0,(5+side)*180, length=steps*(5+side)) ){
-    rgl::rgl.viewpoint(i,0)
+    rgl::view3d(i,0)
   }
   return(side)
 }

--- a/R/plot.rgl.coin.R
+++ b/R/plot.rgl.coin.R
@@ -4,33 +4,34 @@ rgl.coin <- function(x, col='black', heads=x[[1]],
 
   if(missing(x)) x <- TeachingDemos::coin.faces
 
-  rgl::rgl.viewpoint(0,0)
-
+  rgl::view3d(0,0)
+  savecolor <- rgl::material3d(col = "white")
   for(i in 0:39) {
-    rgl::rgl.triangles(c(.5, cos(pi/20*i)/2+0.5, cos(pi/20*(i+1))/2+0.5),
+    rgl::triangles3d(c(.5, cos(pi/20*i)/2+0.5, cos(pi/20*(i+1))/2+0.5),
                   c(.5, sin(pi/20*i)/2+0.5, sin(pi/20*(i+1))/2+0.5),
                   c(0,0,0))
-    rgl::rgl.triangles(c(.5, cos(pi/20*i)/2+0.5, cos(pi/20*(i+1))/2+0.5),
+    rgl::triangles3d(c(.5, cos(pi/20*i)/2+0.5, cos(pi/20*(i+1))/2+0.5),
                   c(.5, sin(pi/20*i)/2+0.5, sin(pi/20*(i+1))/2+0.5),
                   c(0.03,0.03,0.03))
-    rgl::rgl.quads( c(cos(pi/20*i)/2+0.5, cos(pi/20*i)/2+0.5,
+    rgl::quads3d( c(cos(pi/20*i)/2+0.5, cos(pi/20*i)/2+0.5,
                  cos(pi/20*(i+1))/2+0.5, cos(pi/20*(i+1))/2+0.5),
                c(sin(pi/20*i)/2+0.5, sin(pi/20*i)/2+0.5,
                  sin(pi/20*(i+1))/2+0.5, sin(pi/20*(i+1))/2+0.5),
                c(0,0.03,0.03,0)
               )
   }
-
+  rgl::material3d(savecolor)
+  
   tmp <- rep( 1:nrow(heads), each=2 )
   tmp <- c(tmp[-1],1)
 
-  rgl::rgl.lines( heads[tmp,1], heads[tmp,2], rep(0.035, length(tmp) ),
+  rgl::segments3d( heads[tmp,1], heads[tmp,2], rep(0.035, length(tmp) ),
              col=col, lit=FALSE)
 
   tmp <- rep( 1:nrow(tails), each=2 )
   tmp <- c(tmp[-1],1)
 
-  rgl::rgl.lines( tails[tmp,1], tails[tmp,2], rep(-0.005, length(tmp) ),
+  rgl::segments3d( tails[tmp,1], tails[tmp,2], rep(-0.005, length(tmp) ),
              col=col, lit=FALSE)
 
 }

--- a/R/plot.rgl.die.R
+++ b/R/plot.rgl.die.R
@@ -2,7 +2,7 @@ rgl.die <- function(x = 1:6, col.cube='white',col.pip='black',sides=x, ...) {
 
   if(!requireNamespace('rgl', quietly = TRUE)) stop("This function depends on the 'rgl' package wich is not available")
 
-  rgl::rgl.viewpoint(45,45)
+  rgl::view3d(45,45)
 
   pip.coords <- function( x,y ) {
     xc <- yc <- numeric(0)
@@ -21,47 +21,47 @@ rgl.die <- function(x = 1:6, col.cube='white',col.pip='black',sides=x, ...) {
                   cbind( c(.25, .25, .25, .75, .75, .75),
                          c(.25, .5, .75, .75, .5, .25)))
 
-  rgl::rgl.quads( c(0,0,1,1), c(0,1,1,0), c(0,0,0,0), col=col.cube)
-  rgl::rgl.quads( c(0,0,1,1), c(0,1,1,0), c(1,1,1,1), col=col.cube)
-  rgl::rgl.quads( c(0,0,0,0), c(0,1,1,0), c(0,0,1,1), col=col.cube)
-  rgl::rgl.quads( c(1,1,1,1), c(0,1,1,0), c(0,0,1,1), col=col.cube)
-  rgl::rgl.quads( c(0,0,1,1), c(0,0,0,0), c(0,1,1,0), col=col.cube)
-  rgl::rgl.quads( c(0,0,1,1), c(1,1,1,1), c(0,1,1,0), col=col.cube)
+  rgl::quads3d( c(0,0,1,1), c(0,1,1,0), c(0,0,0,0), col=col.cube)
+  rgl::quads3d( c(0,0,1,1), c(0,1,1,0), c(1,1,1,1), col=col.cube)
+  rgl::quads3d( c(0,0,0,0), c(0,1,1,0), c(0,0,1,1), col=col.cube)
+  rgl::quads3d( c(1,1,1,1), c(0,1,1,0), c(0,0,1,1), col=col.cube)
+  rgl::quads3d( c(0,0,1,1), c(0,0,0,0), c(0,1,1,0), col=col.cube)
+  rgl::quads3d( c(0,0,1,1), c(1,1,1,1), c(0,1,1,0), col=col.cube)
 
   tmp <- pip.loc[[ sides[1] ]]
   for( i in 1:nrow(tmp) ){
     xy <- pip.coords( tmp[i,1], tmp[i,2] )
-    rgl::rgl.triangles(xy[,1], rep(1.001, nrow(xy)), xy[,2], col=col.pip,lit=FALSE)
+    rgl::triangles3d(xy[,1], rep(1.001, nrow(xy)), xy[,2], col=col.pip,lit=FALSE)
   }
 
   tmp <- pip.loc[[ sides[2] ]]
   for( i in 1:nrow(tmp) ){
     xy <- pip.coords( tmp[i,1], tmp[i,2] )
-    rgl::rgl.triangles(xy[,1], xy[,2], rep(1.001, nrow(xy)), col=col.pip,lit=FALSE)
+    rgl::triangles3d(xy[,1], xy[,2], rep(1.001, nrow(xy)), col=col.pip,lit=FALSE)
   }
 
   tmp <- pip.loc[[ sides[3] ]]
   for( i in 1:nrow(tmp) ){
     xy <- pip.coords( tmp[i,1], tmp[i,2] )
-    rgl::rgl.triangles( rep(1.001, nrow(xy)), xy[,1], xy[,2], col=col.pip,lit=FALSE)
+    rgl::triangles3d( rep(1.001, nrow(xy)), xy[,1], xy[,2], col=col.pip,lit=FALSE)
   }
 
   tmp <- pip.loc[[ sides[4] ]]
   for( i in 1:nrow(tmp) ){
     xy <- pip.coords( tmp[i,1], tmp[i,2] )
-    rgl::rgl.triangles( rep(-0.001, nrow(xy)), xy[,1], xy[,2], col=col.pip,lit=FALSE)
+    rgl::triangles3d( rep(-0.001, nrow(xy)), xy[,1], xy[,2], col=col.pip,lit=FALSE)
   }
 
   tmp <- pip.loc[[ sides[5] ]]
   for( i in 1:nrow(tmp) ){
     xy <- pip.coords( tmp[i,1], tmp[i,2] )
-    rgl::rgl.triangles(xy[,1], xy[,2], rep(-0.001, nrow(xy)), col=col.pip,lit=FALSE)
+    rgl::triangles3d(xy[,1], xy[,2], rep(-0.001, nrow(xy)), col=col.pip,lit=FALSE)
   }
 
   tmp <- pip.loc[[ sides[6] ]]
   for( i in 1:nrow(tmp) ){
     xy <- pip.coords( tmp[i,1], tmp[i,2] )
-    rgl::rgl.triangles(xy[,1], rep(-0.001, nrow(xy)), xy[,2], col=col.pip,lit=FALSE)
+    rgl::triangles3d(xy[,1], rep(-0.001, nrow(xy)), xy[,2], col=col.pip,lit=FALSE)
   }
 
 }

--- a/R/rgl.Map.R
+++ b/R/rgl.Map.R
@@ -16,7 +16,7 @@ function(Map,which,...) {
         tmp.i <- rep( seq(along=x[pfrom:pto]), each=2 )
         tmp.i <- c(tmp.i[-1], 1)
 
-        rgl::rgl.lines(x[tmp.i], y[tmp.i], z[tmp.i], ...)
+        rgl::segments3d(x[tmp.i], y[tmp.i], z[tmp.i], ...)
     }, shape$Pstart + 1, c(shape$Pstart[-1], shape$nVerts + 1))
 
   })

--- a/R/roll.rgl.die.R
+++ b/R/roll.rgl.die.R
@@ -1,6 +1,6 @@
 roll.rgl.die <- function( side=sample(6,1), steps=250 ) {
 
-  rgl::rgl.viewpoint(45,45)
+  rgl::view3d(45,45)
 
 
   tmp <- seq(45, by=90, length=4)
@@ -8,30 +8,30 @@ roll.rgl.die <- function( side=sample(6,1), steps=250 ) {
   
   for (j in 1:4) {
     for (i in seq(0,90,length=steps)) {
-      rgl::rgl.viewpoint(tmp[j]+i, -tmp2[j]*45+tmp2[j]*i)
+      rgl::view3d(tmp[j]+i, -tmp2[j]*45+tmp2[j]*i)
     }
   }
 
   if( side==1 ){
     for(i in seq(0,45, length=steps/2)) {
-      rgl::rgl.viewpoint(45+i, 45+i)
+      rgl::view3d(45+i, 45+i)
     }
   } else if( side==6 ) {
     for(i in seq(0,90, length=steps)) {
-      rgl::rgl.viewpoint(45+i, 45-i)
+      rgl::view3d(45+i, 45-i)
     }
     for(i in seq(0,45, length=steps/2)) {
-      rgl::rgl.viewpoint(135+i, -45-i)
+      rgl::view3d(135+i, -45-i)
     }
   } else {
     tmp3 <- c(NA,3,0,2,1)[side]
     for(j in seq(1,length=tmp3)){
       for(i in seq(0,90,length=steps)) {
-        rgl::rgl.viewpoint(tmp[j]+i, -tmp2[j]*45+tmp2[j]*i)
+        rgl::view3d(tmp[j]+i, -tmp2[j]*45+tmp2[j]*i)
       }
     }
     for(i in seq(0,45, length=steps/2)) {
-      rgl::rgl.viewpoint(tmp[tmp3+1]+i, -tmp2[tmp3+1]*45+tmp2[tmp3+1]*i)
+      rgl::view3d(tmp[tmp3+1]+i, -tmp2[tmp3+1]*45+tmp2[tmp3+1]*i)
     }
   }
   return(side)

--- a/man/plot.rgl.coin.Rd
+++ b/man/plot.rgl.coin.Rd
@@ -78,12 +78,12 @@ flip.rgl.coin()
 flip.rgl.coin(1)
 flip.rgl.coin(2)
 
-rgl.clear()
+rgl::clear3d()
 
 # two-headed coin
 rgl.coin(tails=coin.faces$qh)
 
-rgl.clear()
+rgl::clear3d()
 
 # letters instead of pictures
 rgl.coin(heads=coin.faces$H, tails=coin.faces$T)
@@ -91,7 +91,7 @@ rgl.coin(heads=coin.faces$H, tails=coin.faces$T)
 # biased flip
 flip.rgl.coin( sample(2,1, prob=c(0.65, 0.35) ) )
 
-rgl.clear()
+rgl::clear3d()
 
 rgl.die()
 roll.rgl.die()

--- a/man/rgl.Map.Rd
+++ b/man/rgl.Map.Rd
@@ -40,7 +40,7 @@ if(interactive()){
 
 tz <- maptools:::read.shape('WRLDTZA')
 rgl.Map(tz)
-rgl.spheres(0,0,0,.999, col='darkblue')
+spheres3d(0,0,0,.999, col='darkblue')
 }
 }
 \keyword{ hplot }% at least one, from doc/KEYWORDS

--- a/man/simfun.Rd
+++ b/man/simfun.Rd
@@ -105,7 +105,7 @@ See the examples for how to use the result function.
 
 simheight <- simfun( {h <- c(64,69); height<-h[sex]+ rnorm(10,0,3)}, drop='h' )
 
-my.df <- data.frame(sex=rep(c('Male','Female'),each=5))
+my.df <- data.frame(sex=factor(rep(c('Male','Female'),each=5)))
 simdat <- simheight(my.df)
 t.test(height~sex, data=simdat)
 


### PR DESCRIPTION
These changes will avoid warnings when the rgl.* calls are deprecated.  I think everything displays the same, but I couldn't check the rgl.Map function, because I couldn't find a copy of the shape file that it uses.  I also couldn't install R2wd, so didn't test anything that needed that.

I also made a couple of unrelated changes to satisfy R CMD check complaints.